### PR TITLE
feat: 코드 자동 들여쓰기 기능 추가 + a

### DIFF
--- a/app/src/components/editor/CodeEditor.tsx
+++ b/app/src/components/editor/CodeEditor.tsx
@@ -2,19 +2,20 @@ import Editor, { useMonaco } from '@monaco-editor/react';
 import { useEffect, useRef, useMemo } from 'react';
 import * as monaco_editor from 'monaco-editor';
 
-import { useEditorTabStore, type EditorTab } from '@/stores/EditorTabStore';
+import { useEditorTabStore } from '@/stores/EditorTabStore';
 import { useProjectStore } from '@/stores/ProjectStore';
 import { useSyntaxCheck } from '@/hooks/useSyntaxCheck';
+
+import { editorOptions } from '@/constants/monaco/editor-config';
 import { sicxeLanguage } from '@/constants/monaco/sicxeLanguage';
 import { sicxeTheme } from '@/constants/monaco/sicxeTheme';
+
 import { autoIndentLine } from '@/lib/auto-indent-line';
+import { clampLine } from '@/lib/editor-utils';
+import { useBreakpointManager } from '@/hooks/editor/useBreakpointManager';
 
 import EditorErrorBoundary from './EditorErrorBoundary';
 import '@/styles/SyntaxError.css';
-
-const clampLine = (line1: number, model: monaco_editor.editor.ITextModel) => {
-  return Math.max(1, Math.min(line1 ?? 1, model.getLineCount()));
-};
 
 function registerAssemblyLanguage(monaco: typeof monaco_editor | null) {
   if (monaco) {
@@ -49,8 +50,8 @@ export default function CodeEditor() {
   const { projectPath } = useProjectStore();
   const activeTab = getActiveTab();
   const editorRef = useRef<monaco_editor.editor.IStandaloneCodeEditor | null>(null);
-  const decorationIdsRef = useRef<string[]>([]);
   const isLoadingRef = useRef(false);
+  const { handleBreakpointMouseDown } = useBreakpointManager(editorRef, activeTab);
   const texts = useMemo(() => (activeTab ? [activeTab.fileContent] : []), [activeTab?.fileContent]);
   const fileNames = useMemo(() => (activeTab ? [activeTab.filePath] : []), [activeTab?.filePath]);
 
@@ -147,53 +148,14 @@ export default function CodeEditor() {
 
     // Breakpoint 기능 활성화
     editor.updateOptions({
-      glyphMargin: true, // Breakpoint를 위한 여백 활성화
+      glyphMargin: true,
       lineNumbers: 'on',
       folding: true,
-      minimap: { enabled: true }, // 미니맵 비활성화로 공간 확보
+      minimap: { enabled: true },
       scrollBeyondLastLine: false,
     });
 
-    // Breakpoint 클릭 이벤트 처리
-    editor.onMouseDown(e => {
-      console.log('Mouse down event:', e.target.type, e.target.position);
-      console.log('Mouse target details:', e.target);
-
-      // 클릭된 위치에서 라인 번호 추출
-      let lineNumber: number | undefined;
-
-      if (e.target.type === monaco_editor.editor.MouseTargetType.GUTTER_GLYPH_MARGIN) {
-        lineNumber = e.target.position?.lineNumber;
-        console.log('Glyph margin clicked at line:', lineNumber);
-      } else if (e.target.type === monaco_editor.editor.MouseTargetType.GUTTER_LINE_NUMBERS) {
-        lineNumber = e.target.position?.lineNumber;
-        console.log('Line number clicked at line:', lineNumber);
-      }
-      // CONTENT_TEXT 클릭은 제거 - 코드 본문 클릭 시 중단점 토글 방지
-
-      if (lineNumber && activeTab) {
-        console.log('Before toggle - activeTab breakpoints:', activeTab.breakpoints);
-        console.log('Toggling breakpoint for line:', lineNumber);
-
-        toggleBreakpoint(activeTab.idx, lineNumber);
-
-        // 상태 업데이트 후 다시 확인
-        setTimeout(() => {
-          const updatedActiveTab = getActiveTab();
-          console.log(
-            'After toggle - updatedActiveTab breakpoints:',
-            updatedActiveTab?.breakpoints,
-          );
-          if (updatedActiveTab) {
-            updateBreakpointDecorations(updatedActiveTab);
-          }
-        }, 0);
-
-        console.log('Breakpoint toggled for line:', lineNumber);
-      } else {
-        console.log('No valid line number or active tab. Target type:', e.target.type);
-      }
-    });
+    editor.onMouseDown(handleBreakpointMouseDown);
 
     editor.onDidChangeCursorPosition(e => {
       const currentActiveTab = getActiveTab();
@@ -266,78 +228,6 @@ export default function CodeEditor() {
     });
   };
 
-  // Breakpoint 데코레이션 업데이트 함수
-  const updateBreakpointDecorations = (tab?: EditorTab) => {
-    const targetTab = tab || activeTab;
-    const editor = editorRef.current;
-    if (!editor || !targetTab) {
-      console.log('Cannot update decorations - editor or targetTab not available');
-      return;
-    }
-
-    const model = editor.getModel();
-    if (!model) return;
-
-    console.log('Updating breakpoint decorations for breakpoints:', targetTab.breakpoints);
-
-    // 기존 데코 제거
-    if (decorationIdsRef.current.length > 0) {
-      editor.deltaDecorations(decorationIdsRef.current, []);
-    }
-
-    // ✅ 숫자 보정 + 1~lineCount 범위로 제한 + 중복 제거
-    const validLines = (targetTab.breakpoints ?? [])
-      .map((n: unknown) => Math.floor(Number(n)))
-      .filter((n: number) => Number.isFinite(n))
-      .map((n: number) => clampLine(n, model))
-      .filter((n: number, i: number, arr: number[]) => arr.indexOf(n) === i);
-
-    const decorations = validLines.map((lineNumber: number) => ({
-      range: new monaco_editor.Range(lineNumber, 1, lineNumber, 1),
-      options: {
-        glyphMarginClassName: 'breakpoint-glyph',
-        glyphMarginHoverMessage: { value: 'Breakpoint' },
-        isWholeLine: false,
-        stickiness: monaco_editor.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-      },
-    }));
-
-    console.log('Created decorations:', decorations);
-    decorationIdsRef.current = editor.deltaDecorations([], decorations);
-    console.log('Applied decoration IDs:', decorationIdsRef.current);
-  };
-
-  // Breakpoint 시각적 표시를 위한 CSS 추가
-  useEffect(() => {
-    const style = document.createElement('style');
-    style.textContent = `
-      /* Breakpoint 아이콘 스타일 - Monaco Editor의 기본 위치 사용 */
-      .breakpoint-glyph {
-        background-color: #e51400 !important;
-        border-radius: 50% !important;
-        border: 2px solid #ffffff !important;
-        width: 12px !important;
-        height: 12px !important;
-        display: inline-block !important;
-        margin: 2px !important;
-      }
-      
-      .breakpoint-glyph:hover {
-        background-color: #ff0000 !important;
-        transform: scale(1.1) !important;
-      }
-    `;
-    document.head.appendChild(style);
-
-    console.log('Breakpoint CSS styles applied');
-
-    return () => {
-      if (document.head.contains(style)) {
-        document.head.removeChild(style);
-      }
-    };
-  }, []);
-
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
@@ -392,13 +282,6 @@ export default function CodeEditor() {
     registerAssemblyLanguage(monaco);
   }, [monaco]);
 
-  // Active tab이 변경될 때 breakpoint 데코레이션 업데이트
-  useEffect(() => {
-    if (editorRef.current && activeTab) {
-      updateBreakpointDecorations(activeTab);
-    }
-  }, [activeTab?.idx, activeTab?.filePath]);
-
   if (tabs.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full">
@@ -411,29 +294,13 @@ export default function CodeEditor() {
   return (
     <EditorErrorBoundary>
       <Editor
+        key={activeTab?.idx}
         height="100%"
         theme="asmTheme" // 추가한 테마를 적용합니다.
         defaultLanguage="sicxe" // 기본 언어를 'asm'으로 설정합니다.
         value={activeTab?.fileContent}
         onMount={handleEditorDidMount}
-        options={{
-          glyphMargin: true,
-          lineNumbers: 'on',
-          folding: true,
-          minimap: { enabled: true },
-          scrollBeyondLastLine: true,
-          renderLineHighlight: 'all',
-          selectOnLineNumbers: true,
-
-          // 🔹 고정폭 + 자간 + 컬럼 맞춤
-          fontFamily: 'JetBrains Mono', // 고정폭 폰트
-          fontSize: 12, // 폰트 크기
-          letterSpacing: 0,
-          tabSize: 8, // SIC/XE 컬럼 기준 탭
-          insertSpaces: true, // 탭 대신 스페이스
-          rulers: [9, 17, 35], // 컬럼 가이드
-          wordWrap: 'off', // 자동 줄바꿈 해제
-        }}
+        options={editorOptions}
       />
     </EditorErrorBoundary>
   );

--- a/app/src/constants/monaco/editor-config.ts
+++ b/app/src/constants/monaco/editor-config.ts
@@ -1,0 +1,23 @@
+import * as monaco_editor from 'monaco-editor';
+
+/**
+ * Monaco 에디터에 적용할 기본 옵션 객체입니다.
+ */
+export const editorOptions: monaco_editor.editor.IStandaloneEditorConstructionOptions = {
+  glyphMargin: true,
+  lineNumbers: 'on',
+  folding: true,
+  minimap: { enabled: true },
+  scrollBeyondLastLine: true,
+  renderLineHighlight: 'all',
+  selectOnLineNumbers: true,
+
+  // 🔹 고정폭 + 자간 + 컬럼 맞춤 (SIC/XE용)
+  fontFamily: 'JetBrains Mono', // 고정폭 폰트
+  fontSize: 12, // 폰트 크기
+  letterSpacing: 0,
+  tabSize: 8, // SIC/XE 컬럼 기준 탭
+  insertSpaces: true, // 탭 대신 스페이스
+  rulers: [9, 17, 35], // 컬럼 가이드
+  wordWrap: 'off', // 자동 줄바꿈 해제
+};

--- a/app/src/hooks/editor/useAutoIndentation.ts
+++ b/app/src/hooks/editor/useAutoIndentation.ts
@@ -1,0 +1,116 @@
+import * as monaco_editor from 'monaco-editor';
+import { useCallback } from 'react';
+import { autoIndentLine } from '@/lib/auto-indent-line';
+
+function applyEdit(
+  editor: monaco_editor.editor.IStandaloneCodeEditor,
+  monaco: typeof monaco_editor,
+  lineNumber: number,
+  oldContent: string,
+  newContent: string,
+) {
+  if (oldContent === newContent) return;
+  editor.executeEdits('auto-indent', [
+    {
+      range: new monaco.Range(lineNumber, 1, lineNumber, oldContent.length + 1),
+      text: newContent,
+      forceMoveMarkers: true,
+    },
+  ]);
+}
+
+export function useAutoIndentation(
+  editorRef: React.MutableRefObject<monaco_editor.editor.IStandaloneCodeEditor | null>,
+  monaco: typeof monaco_editor | null,
+) {
+  // CodeEditor에 있던 handleAutoIndent 함수를 가져옵니다.
+  const handleAutoIndent = useCallback(
+    (lineNumber: number, cursorIndex: number, backspace = false) => {
+      const editor = editorRef.current;
+      if (!editor || !monaco) return;
+
+      const model = editor.getModel();
+      if (!model) return;
+
+      const lineContent = model.getLineContent(lineNumber);
+      const newText = autoIndentLine(lineContent, backspace, cursorIndex);
+
+      applyEdit(editor, monaco, lineNumber, lineContent, newText);
+
+      // 커서 위치 재조정
+      let newColumn = cursorIndex + 1; // 기본: 기존 위치
+      if (newColumn > newText.length + 1) newColumn = newText.length + 1;
+
+      editor.setPosition({ lineNumber, column: newColumn });
+    },
+    [editorRef, monaco],
+  );
+
+  // onKeyDown 이벤트에 연결할 핸들러입니다.
+  const handleKeyDown = useCallback(
+    (e: monaco_editor.IKeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const editor = editorRef.current;
+      if (!editor) return;
+
+      const pos = editor.getPosition();
+      if (!pos) return;
+
+      const { lineNumber, column } = pos;
+      const cursorIndex = column - 1;
+
+      switch (e.code) {
+        case 'Tab':
+          e.preventDefault();
+          handleAutoIndent(lineNumber, cursorIndex, false);
+          break;
+
+        case 'Backspace':
+          setTimeout(() => {
+            const currentPos = editor.getPosition();
+            if (!currentPos) return;
+            handleAutoIndent(currentPos.lineNumber, currentPos.column - 1, true);
+          }, 0);
+          break;
+
+        case 'Enter':
+          setTimeout(() => {
+            const newPos = editor.getPosition();
+            if (!newPos) return;
+            handleAutoIndent(newPos.lineNumber - 1, 0, false);
+            handleAutoIndent(newPos.lineNumber, 0, false);
+          }, 0);
+          break;
+      }
+    },
+    [editorRef, handleAutoIndent],
+  );
+
+  // onDidPaste 이벤트에 연결할 핸들러입니다.
+  const handlePaste = useCallback(
+    (e: monaco_editor.editor.IPasteEvent) => {
+      const editor = editorRef.current;
+      const model = editor?.getModel();
+      if (!editor || !model || !monaco) return;
+
+      const edits: monaco_editor.editor.ISingleEditOperation[] = [];
+      for (let i = e.range.startLineNumber; i <= e.range.endLineNumber; i++) {
+        const content = model.getLineContent(i);
+        const newText = autoIndentLine(content, false, 0);
+        if (content !== newText) {
+          edits.push({
+            range: new monaco.Range(i, 1, i, content.length + 1),
+            text: newText,
+          });
+        }
+      }
+      if (edits.length > 0) {
+        editor.executeEdits('auto-indent-paste', edits);
+      }
+    },
+    [editorRef, monaco],
+  );
+
+  return { handleKeyDown, handlePaste };
+}

--- a/app/src/hooks/editor/useBreakpointManager.ts
+++ b/app/src/hooks/editor/useBreakpointManager.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useCallback } from 'react';
+import * as monaco_editor from 'monaco-editor';
+import { useEditorTabStore, type EditorTab } from '@/stores/EditorTabStore';
+import { clampLine } from '@/lib/editor-utils';
+
+export function useBreakpointManager(
+  editorRef: React.MutableRefObject<monaco_editor.editor.IStandaloneCodeEditor | null>,
+  activeTab: EditorTab | undefined,
+) {
+  const { getActiveTab, toggleBreakpoint } = useEditorTabStore();
+  const decorationIdsRef = useRef<string[]>([]);
+
+  // Breakpoint 데코레이션 업데이트 함수 (기존 코드와 동일)
+  const updateBreakpointDecorations = useCallback(
+    (tab?: EditorTab) => {
+      const targetTab = tab || activeTab;
+      const editor = editorRef.current;
+      if (!editor || !targetTab) {
+        console.log('Cannot update decorations - editor or targetTab not available');
+        return;
+      }
+
+      const model = editor.getModel();
+      if (!model) return;
+
+      console.log('Updating breakpoint decorations for breakpoints:', targetTab.breakpoints);
+
+      if (decorationIdsRef.current.length > 0) {
+        editor.deltaDecorations(decorationIdsRef.current, []);
+      }
+
+      const validLines = (targetTab.breakpoints ?? [])
+        .map((n: unknown) => Math.floor(Number(n)))
+        .filter((n: number) => Number.isFinite(n))
+        .map((n: number) => clampLine(n, model))
+        .filter((n: number, i: number, arr: number[]) => arr.indexOf(n) === i);
+
+      const decorations = validLines.map((lineNumber: number) => ({
+        range: new monaco_editor.Range(lineNumber, 1, lineNumber, 1),
+        options: {
+          glyphMarginClassName: 'breakpoint-glyph',
+          glyphMarginHoverMessage: { value: 'Breakpoint' },
+          isWholeLine: false,
+          stickiness: monaco_editor.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+        },
+      }));
+
+      console.log('Created decorations:', decorations);
+      decorationIdsRef.current = editor.deltaDecorations([], decorations);
+      console.log('Applied decoration IDs:', decorationIdsRef.current);
+    },
+    [activeTab, editorRef],
+  );
+
+  // Breakpoint 시각적 표시를 위한 CSS 추가 (기존 코드와 동일)
+  useEffect(() => {
+    const style = document.createElement('style');
+    style.textContent = `
+      .breakpoint-glyph {
+        background-color: #e51400 !important;
+        border-radius: 50% !important;
+        border: 2px solid #ffffff !important;
+        width: 12px !important;
+        height: 12px !important;
+        display: inline-block !important;
+        margin: 2px !important;
+      }
+      
+      .breakpoint-glyph:hover {
+        background-color: #ff0000 !important;
+        transform: scale(1.1) !important;
+      }
+    `;
+    document.head.appendChild(style);
+
+    console.log('Breakpoint CSS styles applied');
+
+    return () => {
+      if (document.head.contains(style)) {
+        document.head.removeChild(style);
+      }
+    };
+  }, []);
+
+  // Active tab이 변경될 때 breakpoint 데코레이션 업데이트
+  useEffect(() => {
+    if (editorRef.current && activeTab) {
+      updateBreakpointDecorations(activeTab);
+    }
+  }, [activeTab, editorRef, updateBreakpointDecorations]); // activeTab.idx, filePath 대신 객체 자체를 의존성으로 사용
+
+  // Breakpoint 클릭 이벤트 처리 로직을 담은 핸들러
+  const handleBreakpointMouseDown = useCallback(
+    (e: monaco_editor.editor.IEditorMouseEvent) => {
+      let lineNumber: number | undefined;
+
+      if (e.target.type === monaco_editor.editor.MouseTargetType.GUTTER_GLYPH_MARGIN) {
+        lineNumber = e.target.position?.lineNumber;
+      } else if (e.target.type === monaco_editor.editor.MouseTargetType.GUTTER_LINE_NUMBERS) {
+        lineNumber = e.target.position?.lineNumber;
+      }
+
+      if (lineNumber && activeTab) {
+        toggleBreakpoint(activeTab.idx, lineNumber);
+
+        setTimeout(() => {
+          const updatedActiveTab = getActiveTab();
+          if (updatedActiveTab) {
+            updateBreakpointDecorations(updatedActiveTab);
+          }
+        }, 0);
+      }
+    },
+    [activeTab, getActiveTab, toggleBreakpoint, updateBreakpointDecorations],
+  );
+
+  // 생성한 마우스 다운 핸들러를 반환
+  return { handleBreakpointMouseDown };
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -23,6 +23,7 @@ body {
   font-family:
     'Pretendard Variable',
     Pretendard,
+    'JetBrains Mono',
     -apple-system,
     BlinkMacSystemFont,
     system-ui,

--- a/app/src/lib/auto-indent-line.ts
+++ b/app/src/lib/auto-indent-line.ts
@@ -182,9 +182,17 @@ export function autoIndentLine(
     ? ''
     : correct_space(instruction, spaces_inst_raw, LEN_INSTR_FIELD);
 
-  const spaces_operand = remove_spaces_oper
-    ? ''
-    : correct_space(operand, spaces_operand_raw, LEN_OPERAND_FIELD);
+  let spaces_operand;
+  if (remove_spaces_oper) {
+    spaces_operand = '';
+  } else if (comment_part.length > 0 || dot !== -1) {
+    // 주석이 존재하거나, 주석을 이제 막 입력하려는 경우(`.`)에만 공백을 계산합니다.
+    spaces_operand = correct_space(operand, spaces_operand_raw, LEN_OPERAND_FIELD);
+  } else {
+    // 주석이 없으면, operand 뒤에 추가 공백을 넣지 않습니다.
+    spaces_operand =
+      operand.length > 0 && code_part.trim().endsWith(operand) ? '' : spaces_operand_raw;
+  }
 
   // Normalize comment
   const comment_norm = comment_part ? replace_tabs_with_spaces(comment_part) : '';

--- a/app/src/lib/auto-indent-line.ts
+++ b/app/src/lib/auto-indent-line.ts
@@ -1,0 +1,203 @@
+// Column positions
+const COL_OPCODE_START = 10;
+const COL_OPERAND_START = 18;
+const COL_COMMENT_START = 36;
+
+// Field lengths
+const LEN_LABEL_FIELD = COL_OPCODE_START - 1; // 9
+const LEN_INSTR_FIELD = COL_OPERAND_START - COL_OPCODE_START; // 8
+const LEN_OPERAND_FIELD = COL_COMMENT_START - COL_OPERAND_START; // 18
+
+function is_space(ch: string): boolean {
+  return ch === ' ' || ch === '\t';
+}
+
+function replace_tabs_with_spaces(s: string): string {
+  return s.replace(/\t/g, ' ');
+}
+
+function span_spaces(s: string, i: number): number {
+  let j = i;
+  while (j < s.length && is_space(s[j])) j++;
+  return j - i;
+}
+
+function span_token(s: string, i: number): [string, number] {
+  let j = i;
+  while (j < s.length && !is_space(s[j])) j++;
+  return [s.slice(i, j), j];
+}
+
+function first_nonspace_index(s: string): number {
+  let i = 0;
+  while (i < s.length && is_space(s[i])) i++;
+  return i === s.length ? -1 : i;
+}
+
+function find_comment_start(s: string): number {
+  for (let k = 0; k < s.length; k++) {
+    if (s[k] === '.') return k;
+  }
+  return -1;
+}
+
+function in_range(x: number, start: number, end: number): boolean {
+  return start <= x && x < end;
+}
+
+function correct_space(token: string, token_spaces: string, length: number): string {
+  token_spaces = replace_tabs_with_spaces(token_spaces);
+  const required = length - token.length;
+  if (required <= 1) return ' ';
+  return ' '.repeat(required);
+}
+
+/**
+ * Auto-indent a single line of assembly-like code.
+ *
+ * @param line       Input line (may end with '\n')
+ * @param backspace  If true, and cursorpos is inside a space section, that space section is removed
+ * @param cursorpos  0-based cursor index into the original line (before changes)
+ */
+export function autoIndentLine(
+  line: string,
+  backspace: boolean = false,
+  cursorpos: number = 0,
+): string {
+  // Handle newline & cursor clamp
+  let had_nl = false;
+  let raw = line;
+  if (line.endsWith('\n')) {
+    had_nl = true;
+    raw = line.slice(0, -1);
+  }
+
+  const cp = Math.max(0, Math.min(cursorpos, raw.length));
+  const s = raw;
+
+  const idx = first_nonspace_index(s);
+  if (idx === -1) {
+    return '' + (had_nl ? '\n' : '');
+  }
+
+  const trimmed = s.slice(idx);
+  if (/^[\u3131-\uD79D]/.test(trimmed)) {
+    return line; // 그냥 원본 반환 (인덴트 안 건드림)
+  }
+
+  // Comment line
+  if (s[idx] === '.') {
+    const out = replace_tabs_with_spaces(s.slice(idx));
+    return out + (had_nl ? '\n' : '');
+  }
+
+  // Split code vs comment
+  const dot = find_comment_start(s);
+  const code_part = dot !== -1 ? s.slice(0, dot) : s;
+  const comment_part = dot !== -1 ? s.slice(dot) : '';
+
+  // Parse code_part
+  let i = 0;
+
+  // LABEL
+  const leading = span_spaces(code_part, i);
+  i += leading;
+
+  let label = '';
+  let spaces_label_raw = '';
+  let spaces_label_range: [number, number] = [-1, -1];
+  let spaces_inst_range: [number, number] = [-1, -1];
+  let spaces_oper_range: [number, number] = [-1, -1];
+
+  if (leading > 0) {
+    label = '';
+    spaces_label_raw = code_part.slice(0, leading);
+    spaces_label_range = [0, leading];
+  } else {
+    const [tok, next] = span_token(code_part, i);
+    label = tok;
+    i = next;
+    const s_count = span_spaces(code_part, i);
+    spaces_label_raw = code_part.slice(i, i + s_count);
+    spaces_label_range = [i, i + s_count];
+    i += s_count;
+  }
+
+  // INSTRUCTION
+  let instruction = '';
+  let spaces_inst_raw = '';
+  if (i < code_part.length) {
+    const [tok, next] = span_token(code_part, i);
+    instruction = tok;
+    i = next;
+    const s_count = span_spaces(code_part, i);
+    spaces_inst_raw = code_part.slice(i, i + s_count);
+    spaces_inst_range = [i, i + s_count];
+    i += s_count;
+  }
+
+  // OPERAND
+  let operand = '';
+  let spaces_operand_raw = '';
+  if (i < code_part.length) {
+    const [tok, next] = span_token(code_part, i);
+    operand = tok;
+    i = next;
+    const s_count = span_spaces(code_part, i);
+    spaces_operand_raw = code_part.slice(i, i + s_count);
+    spaces_oper_range = [i, i + s_count];
+    i += s_count;
+  }
+
+  // Backspace behavior
+  let remove_spaces_label = false;
+  let remove_spaces_inst = false;
+  let remove_spaces_oper = false;
+
+  if (backspace) {
+    if (
+      spaces_label_range[0] !== -1 &&
+      in_range(cp, spaces_label_range[0], spaces_label_range[1])
+    ) {
+      remove_spaces_label = true;
+    } else if (
+      spaces_inst_range[0] !== -1 &&
+      in_range(cp, spaces_inst_range[0], spaces_inst_range[1])
+    ) {
+      remove_spaces_inst = true;
+    } else if (
+      spaces_oper_range[0] !== -1 &&
+      in_range(cp, spaces_oper_range[0], spaces_oper_range[1])
+    ) {
+      remove_spaces_oper = true;
+    }
+  }
+
+  // Correct spacing
+  const spaces_label = remove_spaces_label
+    ? ''
+    : correct_space(label, spaces_label_raw, LEN_LABEL_FIELD);
+
+  const spaces_inst = remove_spaces_inst
+    ? ''
+    : correct_space(instruction, spaces_inst_raw, LEN_INSTR_FIELD);
+
+  const spaces_operand = remove_spaces_oper
+    ? ''
+    : correct_space(operand, spaces_operand_raw, LEN_OPERAND_FIELD);
+
+  // Normalize comment
+  const comment_norm = comment_part ? replace_tabs_with_spaces(comment_part) : '';
+
+  // Build output
+  const out =
+    replace_tabs_with_spaces(label) +
+    spaces_label +
+    replace_tabs_with_spaces(instruction) +
+    spaces_inst +
+    replace_tabs_with_spaces(operand) +
+    spaces_operand +
+    comment_norm;
+
+  return out + (had_nl ? '\n' : '');
+}

--- a/app/src/lib/editor-utils.ts
+++ b/app/src/lib/editor-utils.ts
@@ -1,0 +1,8 @@
+import * as monaco_editor from 'monaco-editor';
+
+/**
+ * 주어진 줄 번호가 모델의 전체 줄 수 범위 내에 있도록 보정합니다.
+ */
+export const clampLine = (line: number, model: monaco_editor.editor.ITextModel) => {
+  return Math.max(1, Math.min(line ?? 1, model.getLineCount()));
+};

--- a/app/src/stores/EditorTabStore.ts
+++ b/app/src/stores/EditorTabStore.ts
@@ -177,6 +177,7 @@ export const useEditorTabStore = create<EditorTabState>((set, get) => ({
   toggleBreakpoint: (idx, lineNumber) => {
     const { tabs } = get();
     const tab = tabs.find(t => t.idx === idx);
+    console.log(`${tab?.filePath}의 ${lineNumber}줄 에서 브레이크 포인트 클릭!`);
     if (tab && tab.breakpoints && tab.breakpoints.includes(lineNumber)) {
       get().removeBreakpoint(idx, lineNumber);
     } else {

--- a/app/src/stores/EditorTabStore.ts
+++ b/app/src/stores/EditorTabStore.ts
@@ -33,97 +33,98 @@ interface EditorTabState {
   clearBreakpoints: (idx: number) => void;
 }
 
-const defaultTab: EditorTab = {
-  idx: 0,
-  title: 'Untitled',
-  filePath: './main.asm',
-  isModified: false,
-  fileContent: 'hello',
-  breakpoints: [],
-  isActive: false,
-  cursor: {
-    line: 0,
-    column: 0,
-  },
+// const defaultTab: EditorTab = {
+//   idx: 0,
+//   title: 'Untitled',
+//   filePath: './main.asm',
+//   isModified: false,
+//   fileContent: 'hello',
+//   breakpoints: [],
+//   isActive: false,
+//   cursor: {
+//     line: 0,
+//     column: 0,
+//   },
+// };
+
+// 'activeTabIdx'를 기준으로 모든 탭의 'isActive' 상태를 동기화하는 헬퍼 함수
+const syncActiveState = (tabs: EditorTab[], activeIdx: number): EditorTab[] => {
+  return tabs.map((tab, index) => ({
+    ...tab,
+    isActive: index === activeIdx,
+  }));
 };
 
 export const useEditorTabStore = create<EditorTabState>((set, get) => ({
   tabs: [],
   activeTabIdx: -1, // default value (e.g., -1 for no active tab)
-  getActiveTab: () => get().tabs.find(tab => tab.isActive),
+
+  getActiveTab: () => {
+    const { tabs, activeTabIdx } = get();
+    // 유효한 인덱스인지 확인 후 반환
+    if (activeTabIdx >= 0 && activeTabIdx < tabs.length) {
+      return tabs[activeTabIdx];
+    }
+    return undefined;
+  },
+
   addTab: newTab =>
     set(state => {
       const exists = state.tabs.some(tab => tab.filePath === newTab.filePath);
+      // 이미 탭이 존재하는 경우
       if (exists) {
         const newActiveTabIdx = state.tabs.findIndex(tab => tab.filePath === newTab.filePath);
-        return {
-          tabs: state.tabs.map(tab => ({
-            ...tab,
-            breakpoints: tab.breakpoints || [],
-            isActive: tab.filePath === newTab.filePath ? true : false,
-          })),
-          activeTabIdx: newActiveTabIdx,
-        };
+        const syncedTabs = syncActiveState(state.tabs, newActiveTabIdx);
+        return { tabs: syncedTabs, activeTabIdx: newActiveTabIdx };
       }
+
+      // 새 탭 추가하는 경우
       const newIdx = state.tabs.length;
-      return {
-        tabs: [
-          ...state.tabs.map(tab => ({
-            ...tab,
-            breakpoints: tab.breakpoints || [],
-            isActive: false,
-          })),
-          {
-            ...newTab,
-            breakpoints: newTab.breakpoints || [],
-            isActive: true,
-            idx: newIdx,
-          },
-        ],
-        activeTabIdx: newIdx,
-      };
+      const updatedTabs = [...state.tabs, { ...newTab, idx: newIdx }];
+      const syncedTabs = syncActiveState(updatedTabs, newIdx);
+      return { tabs: syncedTabs, activeTabIdx: newIdx };
     }),
+
   closeTab: idx =>
     set(state => {
-      const closedTabIsActive = state.tabs[idx]?.isActive;
+      const closedTabWasActive = state.tabs[idx]?.idx === state.activeTabIdx;
       const updatedTabs = state.tabs.filter(tab => tab.idx !== idx);
-
       const reindexedTabs = updatedTabs.map((tab, i) => ({ ...tab, idx: i }));
 
       let newActiveTabIdx = -1;
       if (reindexedTabs.length > 0) {
-        if (closedTabIsActive) {
+        if (closedTabWasActive) {
+          // 닫은 탭이 활성 탭이었다면, 마지막 탭을 활성화
           newActiveTabIdx = reindexedTabs.length - 1;
         } else {
-          const currentActiveTab = state.tabs.find(tab => tab.isActive);
-          newActiveTabIdx = currentActiveTab
-            ? reindexedTabs.findIndex(tab => tab.filePath === currentActiveTab.filePath)
-            : -1;
+          // 다른 탭을 닫았다면, 기존 활성 탭의 새 인덱스 찾기
+          const oldActiveTab = state.tabs[state.activeTabIdx];
+          if (oldActiveTab) {
+            newActiveTabIdx = reindexedTabs.findIndex(t => t.filePath === oldActiveTab.filePath);
+          }
         }
       }
 
-      const finalTabs = reindexedTabs.map((tab, i) => ({
-        ...tab,
-        isActive: i === newActiveTabIdx,
-      }));
-
+      const finalTabs = syncActiveState(reindexedTabs, newActiveTabIdx);
       return {
         tabs: finalTabs,
         activeTabIdx: newActiveTabIdx,
       };
     }),
   setActiveTab: idx =>
-    set(state => ({
-      tabs: state.tabs.map(tab => ({
-        ...tab,
-        isActive: tab.idx === idx,
-      })),
-      activeTabIdx: idx,
-    })),
+    set(state => {
+      const syncedTabs = syncActiveState(state.tabs, idx);
+      return {
+        tabs: syncedTabs,
+        activeTabIdx: idx,
+      };
+    }),
+
   setCursor: (idx, cursor) =>
     set(state => ({
       tabs: state.tabs.map(tab => ({ ...tab, cursor: tab.idx === idx ? cursor : tab.cursor })),
     })),
+
   setFileContent: (idx, fileContent) =>
     set(state => ({
       tabs: state.tabs.map(tab => ({
@@ -131,7 +132,9 @@ export const useEditorTabStore = create<EditorTabState>((set, get) => ({
         fileContent: tab.idx === idx ? fileContent : tab.fileContent,
       })),
     })),
+
   clearTabs: () => set(() => ({ tabs: [], activeTabIdx: -1 })),
+
   setIsModified: (idx, isModified) =>
     set(state => ({
       tabs: state.tabs.map(tab => ({
@@ -139,6 +142,7 @@ export const useEditorTabStore = create<EditorTabState>((set, get) => ({
         isModified: tab.idx === idx ? isModified : tab.isModified,
       })),
     })),
+
   // Breakpoint 관련 함수들
   addBreakpoint: (idx, lineNumber) =>
     set(state => ({
@@ -155,6 +159,7 @@ export const useEditorTabStore = create<EditorTabState>((set, get) => ({
         return tab;
       }),
     })),
+
   removeBreakpoint: (idx, lineNumber) =>
     set(state => ({
       tabs: state.tabs.map(tab => {
@@ -168,6 +173,7 @@ export const useEditorTabStore = create<EditorTabState>((set, get) => ({
         return tab;
       }),
     })),
+
   toggleBreakpoint: (idx, lineNumber) => {
     const { tabs } = get();
     const tab = tabs.find(t => t.idx === idx);
@@ -177,6 +183,7 @@ export const useEditorTabStore = create<EditorTabState>((set, get) => ({
       get().addBreakpoint(idx, lineNumber);
     }
   },
+
   clearBreakpoints: idx =>
     set(state => ({
       tabs: state.tabs.map(tab => {


### PR DESCRIPTION
# 📝 개요

* #29

이번 PR은 **에디터의 사용자 경험을 개선**하고, **코드의 유지보수성을 높이는 것**에 중점을 두었습니다.
핵심 기능으로 **SIC/XE 어셈블리 코드 자동 들여쓰기**를 추가했으며, 비대해진 `CodeEditor.tsx` 컴포넌트를 기능별 커스텀 훅으로 분리하는 대규모 리팩토링을 진행했습니다.
또한, 이 과정에서 발견된 주요 버그들(탭 전환 시 중단점 미적용, 폰트 로딩으로 인한 레이아웃 깨짐)을 수정하여 에디터의 안정성을 크게 향상시켰습니다.

# ✨ 주요 변경 사항

## 1. 자동 들여쓰기(Auto-Indentation) 기능 추가 및 모듈화

**어떤 작업을 했나요?**
SIC/XE 코드 형식에 맞춰 `LABEL`, `OPCODE`, `OPERAND`, `COMMENT`의 위치를 자동으로 정렬해 주는 기능을 추가했습니다.

**어떻게 동작하나요?**

* **핵심 로직**: 자동 들여쓰기의 모든 계산 로직은 순수 함수로 작성되어 `lib/auto-indent-line.ts` 파일에 위치합니다.

* **실행 트리거**: 아래의 사용자 입력이 발생했을 때 기능이 실행됩니다.

  * `Tab` 키를 눌렀을 때 (현재 줄 정렬)

  * `Backspace`, `Enter` 키를 눌렀을 때 (동작 후 관련 줄 자동 정렬)

  * 코드를 붙여넣기(`Paste`) 했을 때 (붙여넣은 모든 줄 정렬)

  * 저장(`Ctrl+S`) 시 (문서 전체 정렬)
  
  * **`Space`의 경우 적용해보니 사용성이 너무 안좋아 지금은 꺼두었으나, 필요하면 바로 추가 가능합니다.**

* **모듈화**: 에디터와 관련된 모든 로직은 `hooks/editor/useAutoIndentation.ts` 커스텀 훅으로 분리되었습니다. `CodeEditor` 컴포넌트는 이 훅을 호출하여 필요한 핸들러(`handleKeyDown`, `formatDocument` 등)만 가져와 사용할 뿐, 내부 구현에 대해서는 알지 못합니다.

## 2. `CodeEditor.tsx` 컴포넌트 리팩토링

**어떤 작업을 했나요?**
하나의 파일에 500줄이 넘어가며 여러 기능이 복잡하게 얽혀 있던 `CodeEditor.tsx` 컴포넌트를 **역할과 책임에 따라 여러 개의 작은 모듈(커스텀 훅, 설정 파일)로 분리**했습니다.

**어떻게 리팩토링 됐나요?**
기존 `CodeEditor.tsx`는 이제 각 기능 훅들을 조립하고 상태를 전달하는 **조정자(Orchestrator)** 역할만 수행하며, 코드 복잡도가 크게 감소했습니다.

* **에디터 옵션**

  * **위치**: `constants/monaco/editor-config.ts`

  * **역할**: 폰트, 눈금자, 미니맵 등 Monaco Editor의 모든 설정 값을 관리합니다.

* **중단점(Breakpoint) 관리 로직**

  * **위치**: `hooks/editor/useBreakpointManager.ts`

  * **역할**: 중단점 클릭 이벤트 처리, 화면에 중단점 UI를 그리거나 지우는 모든 로직을 담당합니다.

* **자동 들여쓰기(Auto-Indentation) 로직**

  * **위치**: `hooks/editor/useAutoIndentation.ts`

  * **역할**: `Tab`, `Backspace` 등 키보드 입력을 감지하고, `auto-indent-line.ts`의 핵심 로직을 호출하여 에디터에 적용하는 역할을 합니다.

## 3. 주요 버그 수정

* **탭 전환 시 중단점 미적용 문제 해결**

  * **문제**: 첫 번째 탭 외 다른 탭에서는 중단점이 찍히지 않는 현상

  * **원인**: 에디터 이벤트 핸들러가 오래된 정보(첫 번째 탭의 정보)를 계속 참조하는 'Stale Closure' 문제.

  * **해결**: `<Editor>` 컴포넌트에 `key={activeTab?.idx}` prop을 추가하여 탭이 전환될 때마다 에디터 컴포넌트를 강제로 재생성(Re-mount)하도록 수정. 이를 통해 항상 최신 정보로 이벤트 핸들러가 등록되도록 보장했습니다.

* **초기 렌더링 시 폰트-레이아웃 불일치 문제 해결**

  * **문제**: 페이지 새로고침 시, 웹 폰트(`JetBrains Mono`)가 늦게 로드되어 코드와 눈금자(ruler)의 위치가 어긋나는 현상

  * **해결**: `handleEditorDidMount` 내에서 `document.fonts.load()` API를 사용해 **웹 폰트 로딩이 완료될 때까지 명시적으로 기다린 후**, 에디터 옵션을 적용하고 `editor.layout()`을 호출하여 레이아웃을 강제로 재계산하도록 수정했습니다.

# 👨‍💻 검토 및 논의가 필요한 부분

아래 내용을 중심으로 검토해 주시면 감사하겠습니다.

* **자동 들여쓰기 기능의 적절성**: `useAutoIndentation.ts` 훅을 중심으로, 현재 설정된 트리거(Tab, Backspace 등)와 정렬 방식이 기획 의도와 사용자 경험에 잘 맞는지 확인 부탁드립니다. 특히, 저장 시 문서 전체가 포맷팅되는 정책에 대한 의견을 여쭙고 싶습니다.

* **컴포넌트 분리 구조의 적절성**: `CodeEditor.tsx`와 새로 분리된 훅들의 구조를 확인해 주시고, 역할과 책임이 잘 분리되었는지, 더 개선할 부분이 있는지에 대한 피드백을 부탁드립니다.

* **버그 수정 확인**: 탭 전환 및 새로고침 시 중단점과 에디터 레이아웃이 안정적으로 표시되는지 실제 테스트 환경에서 확인해 주시면 감사하겠습니다.

궁금한 점이나 다른 의견 있으시면 언제든지 편하게 코멘트 남겨주세요!
