### PR TITLE
feat: 에디터 문법 체크에 디바운스 적용

### DIFF
--- a/app/src/hooks/editor/useDebounceFn.ts
+++ b/app/src/hooks/editor/useDebounceFn.ts
@@ -1,0 +1,17 @@
+// useDebounceFn.ts
+import { useRef, useCallback } from 'react';
+
+export function useDebounceFn<T extends (...args: string[][]) => unknown>(
+  fn: T,
+  delay: number,
+): (...args: Parameters<T>) => void {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => fn(...args), delay);
+    },
+    [fn, delay],
+  );
+}

--- a/app/src/hooks/editor/useSyntaxCheck.ts
+++ b/app/src/hooks/editor/useSyntaxCheck.ts
@@ -44,5 +44,10 @@ export function useSyntaxCheck() {
     }
   }, []);
 
-  return { result, loading, error, runCheck };
+  return {
+    result,
+    loading,
+    error,
+    runCheck,
+  };
 }


### PR DESCRIPTION
- `CodeEditor.tsx`의 53번째 줄에 디바운스로 감싼 `runCheck`를 선언
  - 1초 디바운스로 세팅
- 공백, 탭, 엔터 입력시에만 디바운스 적용

```tsx
// Debounce된 runCheck 함수, 지금은 1000ms로 설정
const debouncedRunCheck = useDebounceFn(runCheck, 1000);

// ...

// 구문 분석 (공백, 탭, 엔터)
if (key === ' ' || key === 'Tab' || key === 'Enter') {
  if (editor) {
    debouncedRunCheck([editor.getValue()], [activeTab!.filePath]);
  }
}
```