### PR TITLE
fix: debounce 로직 수정 + 개발자 도구 dev모드에서 표시

### DIFF
--- a/app/electron/menu.ts
+++ b/app/electron/menu.ts
@@ -1,6 +1,8 @@
 import { app, BrowserWindow, shell } from 'electron';
 import path from 'path';
 
+const isDevtoolsEnabled = process.env.SHOW_DEVTOOLS === 'true';
+
 export const menuList = [
   {
     label: 'Application',
@@ -86,9 +88,14 @@ export const menuList = [
   {
     label: 'View',
     submenu: [
-      // { role: 'reload' },
-      // { role: 'forceReload' },
-      // { role: 'toggleDevTools' },
+      ...(isDevtoolsEnabled
+        ? [
+            { role: 'reload' },
+            { role: 'forceReload' },
+            { role: 'toggleDevTools' },
+            { type: 'separator' },
+          ]
+        : []),
       { type: 'separator' },
       { role: 'resetZoom' },
       { role: 'zoomIn' },

--- a/app/package.json
+++ b/app/package.json
@@ -8,17 +8,18 @@
   "main": "./dist/main/index.js",
   "productName": "UmJoonSIC",
   "scripts": {
-    "dev": "electron-vite dev",
-    "start": "electron-forge start",
+    "dev": "cross-env SHOW_DEVTOOLS=true electron-vite dev",
+    "dev:no-devtools": "cross-env SHOW_DEVTOOLS=false electron-vite dev",
+    "start": "cross-env SHOW_DEVTOOLS=false electron-forge start",
     "build": "tsc -b && vite build",
     "premake": "electron-vite build",
     "prepackage": "electron-vite build",
     "lint": "eslint .",
     "format": "prettier --write .",
     "preview": "vite preview",
-    "prebuild": "electron-vite build",
-    "package": "electron-forge package",
-    "make": "electron-forge make"
+    "prebuild": "cross-env SHOW_DEVTOOLS=false electron-vite build",
+    "package": "cross-env SHOW_DEVTOOLS=false electron-forge package",
+    "make": "cross-env SHOW_DEVTOOLS=false electron-forge make"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
@@ -64,6 +65,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react-swc": "^3.11.0",
+    "cross-env": "^10.0.0",
     "electron": "37.2.6",
     "electron-vite": "^4.0.0",
     "eslint": "^9.32.0",

--- a/app/package.json
+++ b/app/package.json
@@ -36,6 +36,7 @@
     "clsx": "^2.1.1",
     "electron": "^37.2.6",
     "electron-squirrel-startup": "^1.0.1",
+    "es-toolkit": "^1.39.10",
     "lucide-react": "^0.540.0",
     "monaco-editor": "^0.52.2",
     "path-browserify": "^1.0.1",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^3.11.0
         version: 3.11.0(vite@7.1.1(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1))
+      cross-env:
+        specifier: ^10.0.0
+        version: 10.0.0
       electron-vite:
         specifier: ^4.0.0
         version: 4.0.0(@swc/core@1.13.3)(vite@7.1.1(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1))
@@ -386,6 +389,9 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.25.8':
     resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
@@ -1495,6 +1501,11 @@ packages:
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
+
+  cross-env@10.0.0:
+    resolution: {integrity: sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
@@ -3756,6 +3767,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild/aix-ppc64@0.25.8':
     optional: true
 
@@ -4734,6 +4747,11 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cross-dirname@0.1.0: {}
+
+  cross-env@10.0.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@6.0.6:
     dependencies:

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       electron-squirrel-startup:
         specifier: ^1.0.1
         version: 1.0.1
+      es-toolkit:
+        specifier: ^1.39.10
+        version: 1.39.10
       lucide-react:
         specifier: ^0.540.0
         version: 0.540.0(react@19.1.1)
@@ -1665,6 +1668,9 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.39.10:
+    resolution: {integrity: sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -4951,6 +4957,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  es-toolkit@1.39.10: {}
 
   es6-error@4.1.1:
     optional: true

--- a/app/src/hooks/editor/useDebounceFn.ts
+++ b/app/src/hooks/editor/useDebounceFn.ts
@@ -1,17 +1,7 @@
-// useDebounceFn.ts
-import { useRef, useCallback } from 'react';
+import { useMemo } from 'react';
+import { debounce } from 'es-toolkit/function';
 
-export function useDebounceFn<T extends (...args: string[][]) => unknown>(
-  fn: T,
-  delay: number,
-): (...args: Parameters<T>) => void {
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  return useCallback(
-    (...args: Parameters<T>) => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      timeoutRef.current = setTimeout(() => fn(...args), delay);
-    },
-    [fn, delay],
-  );
+export function useDebounceFn<T extends (...args: string[][]) => unknown>(fn: T, delay: number) {
+  const debounced = useMemo(() => debounce(fn, delay), [fn, delay]);
+  return debounced;
 }


### PR DESCRIPTION
## `useDebounceFn` 디바운스를 `es-toolkit`으로 교체
- 기존 `setTimeout` 기반 디바운스를 `es-toolkit`의 `debounce`로 교체했습니다.
- `useRef`와 수동 타이머 관리를 제거
- `cancel`, `flush`, `schedule` 메서드를 가진 디바운스 함수 반환

## `SHOW_DEVTOOLS` 환경변수로 개발자 도구 자동 오픈 제어
```json
"scripts": {
  "dev": "cross-env SHOW_DEVTOOLS=true electron-vite dev",
  "dev:no-devtools": "cross-env SHOW_DEVTOOLS=false electron-vite dev",
  "start": "cross-env SHOW_DEVTOOLS=false electron-forge start",
  "prebuild": "cross-env SHOW_DEVTOOLS=false electron-vite build",
  "package": "cross-env SHOW_DEVTOOLS=false electron-forge package",
  "make": "cross-env SHOW_DEVTOOLS=false electron-forge make"
},
```
- View 메뉴에서도 환경변수에 따라 DevTools 항목 조건부 표시
- `cross-env`로 여러 운영체제에 맞춰 환경변수 주입